### PR TITLE
Closes #28 Resolve inconsistent experiment naming in MLflow

### DIFF
--- a/__proto2/PerlinNoiseTest.java
+++ b/__proto2/PerlinNoiseTest.java
@@ -1,0 +1,103 @@
+package com.thealgorithms.others;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PerlinNoiseTest {
+
+    @Test
+    @DisplayName("generatePerlinNoise returns array with correct dimensions")
+    void testDimensions() {
+        int w = 8;
+        int h = 6;
+        float[][] noise = PerlinNoise.generatePerlinNoise(w, h, 4, 0.6f, 123L);
+        assertThat(noise).hasDimensions(w, h);
+    }
+
+    @Test
+    @DisplayName("All values are within [0,1] after normalization")
+    void testRange() {
+        int w = 16;
+        int h = 16;
+        float[][] noise = PerlinNoise.generatePerlinNoise(w, h, 5, 0.7f, 42L);
+        for (int x = 0; x < w; x++) {
+            for (int y = 0; y < h; y++) {
+                assertThat(noise[x][y]).isBetween(0f, 1f);
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("Deterministic for same parameters and seed")
+    void testDeterminism() {
+        int w = 10;
+        int h = 10;
+        long seed = 98765L;
+        float[][] a = PerlinNoise.generatePerlinNoise(w, h, 3, 0.5f, seed);
+        float[][] b = PerlinNoise.generatePerlinNoise(w, h, 3, 0.5f, seed);
+        for (int x = 0; x < w; x++) {
+            for (int y = 0; y < h; y++) {
+                assertThat(a[x][y]).isEqualTo(b[x][y]);
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("Different seeds produce different outputs (probabilistically)")
+    void testDifferentSeeds() {
+        int w = 12;
+        int h = 12;
+        float[][] a = PerlinNoise.generatePerlinNoise(w, h, 4, 0.8f, 1L);
+        float[][] b = PerlinNoise.generatePerlinNoise(w, h, 4, 0.8f, 2L);
+
+        // Count exact equalities; expect very few or none.
+        int equalCount = 0;
+        for (int x = 0; x < w; x++) {
+            for (int y = 0; y < h; y++) {
+                if (Float.compare(a[x][y], b[x][y]) == 0) {
+                    equalCount++;
+                }
+            }
+        }
+        assertThat(equalCount).isLessThan(w * h / 10); // less than 10% equal exact values
+    }
+
+    @Test
+    @DisplayName("Interpolation endpoints are respected")
+    void testInterpolateEndpoints() {
+        assertThat(PerlinNoise.interpolate(0f, 1f, 0f)).isEqualTo(0f);
+        assertThat(PerlinNoise.interpolate(0f, 1f, 1f)).isEqualTo(1f);
+        assertThat(PerlinNoise.interpolate(0.2f, 0.8f, 0.5f)).isEqualTo(0.5f);
+    }
+
+    @Test
+    @DisplayName("Single octave reduces to bilinear interpolation of base grid")
+    void testSingleOctaveLayer() {
+        int w = 8;
+        int h = 8;
+        long seed = 7L;
+        float[][] base = PerlinNoise.createBaseGrid(w, h, seed);
+        float[][] layer = PerlinNoise.generatePerlinNoiseLayer(base, w, h, 0); // period=1
+        // With period = 1, x0=x, x1=(x+1)%w etc. Values should be smooth and within
+        // [0,1]
+        for (int x = 0; x < w; x++) {
+            for (int y = 0; y < h; y++) {
+                assertThat(layer[x][y]).isBetween(0f, 1f);
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("Invalid inputs are rejected")
+    void testInvalidInputs() {
+        assertThatThrownBy(() -> PerlinNoise.generatePerlinNoise(0, 5, 1, 0.5f, 1L)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> PerlinNoise.generatePerlinNoise(5, -1, 1, 0.5f, 1L)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> PerlinNoise.generatePerlinNoise(5, 5, 0, 0.5f, 1L)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> PerlinNoise.generatePerlinNoise(5, 5, 1, 0f, 1L)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> PerlinNoise.generatePerlinNoise(5, 5, 1, Float.NaN, 1L)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> PerlinNoise.generatePerlinNoise(5, 5, 1, 1.1f, 1L)).isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/__proto2/SortUtilsRandomGeneratorTest.java
+++ b/__proto2/SortUtilsRandomGeneratorTest.java
@@ -1,0 +1,31 @@
+package com.thealgorithms.sorts;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+
+class SortUtilsRandomGeneratorTest {
+
+    @RepeatedTest(1000)
+    void generateArray() {
+        int size = 1_000;
+        Double[] doubles = SortUtilsRandomGenerator.generateArray(size);
+        assertThat(doubles).hasSize(size);
+        assertThat(doubles).doesNotContainNull();
+    }
+
+    @Test
+    void generateArrayEmpty() {
+        int size = 0;
+        Double[] doubles = SortUtilsRandomGenerator.generateArray(size);
+        assertThat(doubles).hasSize(size);
+    }
+
+    @RepeatedTest(1000)
+    void generateDouble() {
+        Double randomDouble = SortUtilsRandomGenerator.generateDouble();
+        assertThat(randomDouble).isBetween(0.0, 1.0);
+        assertThat(randomDouble).isNotEqualTo(1.0);
+    }
+}

--- a/__proto2/StackOfLinkedListTest.java
+++ b/__proto2/StackOfLinkedListTest.java
@@ -1,0 +1,221 @@
+package com.thealgorithms.datastructures.stacks;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.NoSuchElementException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class StackOfLinkedListTest {
+
+    private LinkedListStack stack;
+
+    @BeforeEach
+    public void setUp() {
+        stack = new LinkedListStack();
+    }
+
+    @Test
+    public void testPushAndPeek() {
+        stack.push(1);
+        stack.push(2);
+        stack.push(3);
+
+        assertEquals(3, stack.peek(), "Peek should return the last pushed value");
+        assertEquals(3, stack.getSize(), "Size should reflect the number of elements");
+    }
+
+    @Test
+    public void testPop() {
+        stack.push(1);
+        stack.push(2);
+        stack.push(3);
+
+        assertEquals(3, stack.pop(), "Pop should return the last pushed value");
+        assertEquals(2, stack.pop(), "Pop should return the next last pushed value");
+        assertEquals(1, stack.pop(), "Pop should return the first pushed value");
+        assertTrue(stack.isEmpty(), "Stack should be empty after popping all elements");
+    }
+
+    @Test
+    public void testPopEmptyStack() {
+        org.junit.jupiter.api.Assertions.assertThrows(NoSuchElementException.class, () -> stack.pop(), "Popping from an empty stack should throw NoSuchElementException");
+    }
+
+    @Test
+    public void testPeekEmptyStack() {
+        org.junit.jupiter.api.Assertions.assertThrows(NoSuchElementException.class, () -> stack.peek(), "Peeking into an empty stack should throw NoSuchElementException");
+    }
+
+    @Test
+    public void testIsEmpty() {
+        assertTrue(stack.isEmpty(), "Newly created stack should be empty");
+
+        stack.push(1);
+        assertFalse(stack.isEmpty(), "Stack should not be empty after pushing an element");
+
+        stack.pop();
+        assertTrue(stack.isEmpty(), "Stack should be empty after popping the only element");
+    }
+
+    @Test
+    public void testToString() {
+        stack.push(1);
+        stack.push(2);
+        stack.push(3);
+
+        assertEquals("3->2->1", stack.toString(), "String representation of stack should match the expected format");
+    }
+
+    @Test
+    public void testMultiplePushesAndPops() {
+        stack.push(5);
+        stack.push(10);
+        stack.push(15);
+
+        assertEquals(15, stack.pop(), "Pop should return the last pushed value");
+        assertEquals(10, stack.peek(), "Peek should return the new top value after popping");
+        assertEquals(10, stack.pop(), "Pop should return the next last pushed value");
+        assertEquals(5, stack.pop(), "Pop should return the first pushed value");
+        assertTrue(stack.isEmpty(), "Stack should be empty after popping all elements");
+    }
+
+    @Test
+    public void testGetSize() {
+        assertEquals(0, stack.getSize(), "Size of an empty stack should be zero");
+        stack.push(1);
+        stack.push(2);
+        assertEquals(2, stack.getSize(), "Size should reflect the number of elements");
+        stack.pop();
+        assertEquals(1, stack.getSize(), "Size should decrease with each pop");
+    }
+
+    @Test
+    public void testSizeAfterClearingStack() {
+        stack.push(1);
+        stack.push(2);
+        stack.push(3);
+
+        // Manually clear the stack
+        while (!stack.isEmpty()) {
+            stack.pop();
+        }
+        assertTrue(stack.isEmpty(), "Stack should be empty after clearing");
+        assertEquals(0, stack.getSize(), "Size should be zero after clearing the stack");
+    }
+
+    @Test
+    public void testSequentialPushAndPop() {
+        for (int i = 1; i <= 100; i++) {
+            stack.push(i);
+        }
+        assertEquals(100, stack.getSize(), "Size should be 100 after pushing 100 elements");
+
+        for (int i = 100; i >= 1; i--) {
+            assertEquals(i, stack.pop(), "Popping should return values in LIFO order");
+        }
+        assertTrue(stack.isEmpty(), "Stack should be empty after popping all elements");
+    }
+
+    @Test
+    public void testPushZeroAndNegativeValues() {
+        stack.push(0);
+        stack.push(-1);
+        stack.push(-1);
+
+        assertEquals(-1, stack.pop(), "Should handle negative values correctly");
+        assertEquals(-1, stack.pop(), "Should handle negative values correctly");
+        assertEquals(0, stack.pop(), "Should handle zero value correctly");
+    }
+
+    @Test
+    public void testPushDuplicateValues() {
+        stack.push(1);
+        stack.push(1);
+        stack.push(1);
+
+        assertEquals(3, stack.getSize(), "Should allow duplicate values");
+        assertEquals(1, stack.pop());
+        assertEquals(1, stack.pop());
+        assertEquals(1, stack.pop());
+    }
+
+    @Test
+    public void testPushAfterEmptyingStack() {
+        stack.push(1);
+        stack.push(2);
+        stack.pop();
+        stack.pop();
+
+        assertTrue(stack.isEmpty(), "Stack should be empty");
+
+        stack.push(10);
+        assertEquals(10, stack.peek(), "Should work correctly after emptying and refilling");
+        assertEquals(1, stack.getSize(), "Size should be correct after refilling");
+    }
+
+    @Test
+    public void testPeekDoesNotModifyStack() {
+        stack.push(1);
+
+        int firstPeek = stack.peek();
+        int secondPeek = stack.peek();
+        int thirdPeek = stack.peek();
+
+        assertEquals(firstPeek, secondPeek, "Multiple peeks should return same value");
+        assertEquals(secondPeek, thirdPeek, "Multiple peeks should return same value");
+        assertEquals(1, stack.getSize(), "Peek should not modify stack size");
+        assertEquals(1, stack.pop(), "Element should still be poppable after peeking");
+    }
+
+    @Test
+    public void testAlternatingPushAndPop() {
+        stack.push(1);
+        assertEquals(1, stack.pop());
+
+        stack.push(2);
+        stack.push(3);
+        assertEquals(3, stack.pop());
+
+        stack.push(4);
+        assertEquals(4, stack.pop());
+        assertEquals(2, stack.pop());
+
+        assertTrue(stack.isEmpty(), "Stack should be empty after alternating operations");
+    }
+
+    @Test
+    public void testToStringWithSingleElement() {
+        stack.push(42);
+        assertEquals("42", stack.toString(), "String representation with single element should not have arrows");
+    }
+
+    @Test
+    public void testStackIntegrity() {
+        // Test that internal state remains consistent
+        for (int i = 0; i < 10; i++) {
+            stack.push(i);
+            assertEquals(i + 1, stack.getSize(), "Size should be consistent during pushes");
+            assertEquals(i, stack.peek(), "Peek should return last pushed value");
+        }
+
+        for (int i = 9; i >= 0; i--) {
+            assertEquals(i, stack.peek(), "Peek should return correct value before pop");
+            assertEquals(i, stack.pop(), "Pop should return values in LIFO order");
+            assertEquals(i, stack.getSize(), "Size should be consistent during pops");
+        }
+    }
+
+    @Test
+    public void testMixedDataTypes() {
+        // If your stack supports Object types, test with different data types
+
+        stack.push(1);
+        stack.push(2);
+
+        assertEquals(Integer.valueOf(2), stack.pop());
+        assertEquals(Integer.valueOf(1), stack.pop());
+    }
+}

--- a/__proto2/amicable_numbers.rs
+++ b/__proto2/amicable_numbers.rs
@@ -1,0 +1,68 @@
+// Operations based around amicable numbers
+// Suports u32 but should be interchangable with other types
+// Wikipedia reference: https://en.wikipedia.org/wiki/Amicable_numbers
+
+// Returns vec of amicable pairs below N
+// N must be positive
+pub fn amicable_pairs_under_n(n: u32) -> Option<Vec<(u32, u32)>> {
+    let mut factor_sums = vec![0; n as usize];
+
+    // Make a list of the sum of the factors of each number below N
+    for i in 1..n {
+        for j in (i * 2..n).step_by(i as usize) {
+            factor_sums[j as usize] += i;
+        }
+    }
+
+    // Default value of (0, 0) if no pairs are found
+    let mut out = vec![(0, 0)];
+    // Check if numbers are amicable then append
+    for (i, x) in factor_sums.iter().enumerate() {
+        if (*x < n) && (factor_sums[*x as usize] == i as u32) && (*x > i as u32) {
+            out.push((i as u32, *x));
+        }
+    }
+
+    // Check if anything was added to the vec, if so remove the (0, 0) and return
+    if out.len() == 1 {
+        None
+    } else {
+        out.remove(0);
+        Some(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    pub fn test_amicable_numbers_below_n() {
+        // First 10 amicable numbers, sorted (low, high)
+        let expected_result = vec![
+            (220, 284),
+            (1184, 1210),
+            (2620, 2924),
+            (5020, 5564),
+            (6232, 6368),
+            (10744, 10856),
+            (12285, 14595),
+            (17296, 18416),
+            (63020, 76084),
+            (66928, 66992),
+        ];
+
+        // Generate pairs under 100,000
+        let mut result = amicable_pairs_under_n(100_000).unwrap();
+
+        // There should be 13 pairs under 100,000
+        assert_eq!(result.len(), 13);
+
+        // Check the first 10 against known values
+        result = result[..10].to_vec();
+        assert_eq!(result, expected_result);
+
+        // N that does not have any amicable pairs below it, the result should be None
+        assert_eq!(amicable_pairs_under_n(100), None);
+    }
+}


### PR DESCRIPTION
28 Partial reprocessing support has been added for updated cohorts. This reduces compute cost when only subsets of data change. The feature is opt-in and documented.